### PR TITLE
change fetch and markup functions like Bohdan ask me

### DIFF
--- a/src/js/fetchByCategories.js
+++ b/src/js/fetchByCategories.js
@@ -3,24 +3,22 @@ import axios from 'axios';
 import { Paginator } from './paginator.js';
 const { API_KEY } = options;
 
-function fetchByChoosenCategories(category) {
-  return axios
-    .get(
-      `https://api.nytimes.com/svc/news/v3/content/all/${category}.json?api-key=${API_KEY}`
-    )
-    .then(response => {
-      const {
-        data: { results },
-      } = response;
-      const responseURL = response.config.url;
-      const paginator = new Paginator();
-      //   paginator.getURL(responseURL);
-      paginator.getRespForPagination(responseURL);
-      markupForSearchByCategories(results);
-    });
+async function fetchByChoosenCategories(category) {
+  const fetch = await axios.get(
+    `https://api.nytimes.com/svc/news/v3/content/all/${category}.json?api-key=${API_KEY}`
+  );
+  return fetch;
+  // .then(response => {
+  //   const {
+  //     data: { results },
+  //   } = response;
+  //   const responseURL = response.config.url;
+  //   const paginator = new Paginator();
+  //   //   paginator.getURL(responseURL);
+  //   paginator.getRespForPagination(responseURL);
+  //   markupForSearchByCategories(results);
+  // });
 }
-
-// fetchByChoosenCategories('food');
 
 function createDataObjectByFetchCategories(arr) {
   const defaultImg = `https://cdn.create.vista.com/api/media/small/251043028/stock-photo-selective-focus-black-news-lettering`;
@@ -49,7 +47,7 @@ function createDataObjectByFetchCategories(arr) {
 }
 function markupForSearchByCategories(arr) {
   const defaultImg = `https://cdn.create.vista.com/api/media/small/251043028/stock-photo-selective-focus-black-news-lettering`;
-  const markup = arr
+  return arr
     .map(news => {
       if (news.multimedia.length === 0) {
         return `

--- a/src/js/fetchByInputAndDate.js
+++ b/src/js/fetchByInputAndDate.js
@@ -21,24 +21,25 @@ const dayAwaliableForBackend = `${today.year()}${today.month()}${today.date()}`;
 
 //Дата передается в виде строки 00000000. По порядку: где 0000 - год, 00- месяц , 00- день Например: 20210122
 // Приходит 10 новостей
-function fetchByInputSerchAndDate(
+async function fetchByInputSerchAndDate(
   query = 'Ukraine',
   date = dayAwaliableForBackend
 ) {
-  return axios
-    .get(`${NEWS_URL}&q=${query}&begin_date=${date}&end_date=${date}`)
-    .then(answer => {
-      const {
-        data: {
-          response: { docs },
-        },
-      } = answer;
-      const responseURL = answer.config.url;
-      const paginator = new Paginator();
-      paginator.getURL(responseURL);
-      paginator.getRespForPagination(responseURL);
-      markupForQuareByInput(docs);
-    });
+  const fetch = await axios.get(
+    `${NEWS_URL}&q=${query}&begin_date=${date}&end_date=${date}`
+  );
+  return fetch;
+  // .then(answer => {
+  //   const {
+  //     data: {
+  //       response: { docs },
+  //     },
+  //   } = answer;
+  //   const responseURL = answer.config.url;
+  //   const paginator = new Paginator();
+  //   paginator.getURL(responseURL);
+  //   paginator.getRespForPagination(responseURL);
+  //   markupForQuareByInput(docs);
 }
 
 function createDataObjectByFetchDateAndInput(arr) {
@@ -69,7 +70,7 @@ function createDataObjectByFetchDateAndInput(arr) {
 }
 
 function markupForQuareByInput(arr) {
-  const markup = arr
+  return arr
     .map(news => {
       const defaultImg = `https://cdn.create.vista.com/api/media/small/251043028/stock-photo-selective-focus-black-news-lettering`;
       const attachURL = `https://www.nytimes.com/`;

--- a/src/js/fetchMostPopular.js
+++ b/src/js/fetchMostPopular.js
@@ -4,17 +4,19 @@ import axios from 'axios';
 import { Paginator } from './paginator.js';
 const { API_KEY } = options;
 const mostPopularUrl = `https://api.nytimes.com/svc/mostpopular/v2/viewed/30.json?api-key=${API_KEY}`;
-function fetchMostPopular() {
-  return axios.get(mostPopularUrl).then(response => {
-    const {
-      data: { results },
-    } = response;
-    const responseURL = response.config.url;
-    const paginator = new Paginator();
-    paginator.getURL(responseURL);
-    paginator.getRespForPagination(responseURL);
-    markupForMostPopular(results);
-  });
+
+async function fetchMostPopular() {
+  const fetch = await axios.get(mostPopularUrl);
+  return fetch;
+  //   then(response => {
+  //     const {
+  //       data: { results },
+  //     } = response;
+  //     const responseURL = response.config.url;
+  //     const paginator = new Paginator();
+  //     paginator.getURL(responseURL);
+  //     paginator.getRespForPagination(responseURL);
+  //     markupForMostPopular(results);
 }
 // Приходит 20 новостей
 
@@ -47,7 +49,7 @@ function createDataObjectByFetchMostPopular(arr) {
 
 function markupForMostPopular(arr) {
   const defaultImg = `https://cdn.create.vista.com/api/media/small/251043028/stock-photo-selective-focus-black-news-lettering`;
-  const markup = arr
+  return arr
     .map(news => {
       if (news.media.length === 0) {
         return `


### PR DESCRIPTION
Привет смотри когда ты это увидишь я буду спать. Я сделал как просил Богдан, ну и так на мой взгляд лучше. Я возвращаю с функции fetch промис, на котором он сможет получить массив объектов то есть данные с бека и уже сам сможет решать что ему делать в этой функции, ну даже кнопку какуюто скрыть например, он не сможет если я оставлю в старом виде. Так же я возвращаю маркап, для того что бы каждый сам решал как ему работать с этим маркапом. Так как если в саму функции markup запишу например ul.innerHTML = markup, а разработчику надо insertAdjacementHTML то он не сможет поменять, а делать куча параметров для этого ну это бред, по этому оттуда я буду возвращать просто маркап, так как это само прваильно. Закоментированный код он сможет, просто взять и вставить куда ему надо и уже на возвращеном промисе с функций fetch он получит данные с бека, и там куча приколов с пагинатором, по этому пусть так и будет. Я считаю так правильно и лучше, тут он прав.  Так как моя функция, котороая была она не ситуативна, а заточена по одно действие, что не правильно. 